### PR TITLE
 #60 time型のバリデーションエラー解消

### DIFF
--- a/app/Livewire/EditPlansForm.php
+++ b/app/Livewire/EditPlansForm.php
@@ -66,7 +66,7 @@ class EditPlansForm extends Component
                 return [
                     'id' => $plan->id,
                     'date' => $plan->date,
-                    'time' => $plan->time,
+                    'time' => substr($plan->time, 0, 5),
                     'plans_title' => $plan->plans_title,
                     'content' => $plan->content,
                     'planFiles' => [null],

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -16,12 +16,6 @@ class Plan extends Model
         'order',
     ];
 
-    public function getTimeAttribute($value)
-    {
-        // Carbonインスタンスを生成して、formatで整形して返す
-        return Carbon::createFromFormat('H:i:s', $value)->format('H:i');
-    }
-
     public function travelOverview()
     {
         return $this->belongsTo(TravelOverview::class, 'travel_id');


### PR DESCRIPTION
Issue
#60 

以前のプルリク
#112 

・以前作成修正したコードでは、何も入力していない時にエラーが出る。そのため、修正ページで初期値をロードする際にH:i型に変換