### PR TITLE
 #125 パスワードが一致しないバリデーションエラー解消

### DIFF
--- a/app/Livewire/EditPlansForm.php
+++ b/app/Livewire/EditPlansForm.php
@@ -44,6 +44,7 @@ class EditPlansForm extends Component
 
     public $shared_password_check;
     public $shared_password;
+    public $shared_password_confirmation;
     public $showPasswordField = false;
 
     protected function rules(): array

--- a/app/Livewire/PlansForm.php
+++ b/app/Livewire/PlansForm.php
@@ -29,6 +29,7 @@ class PlansForm extends Component
     public $souvenirs = [];
     public $additionalComments = [];
     public $shared_password;
+    public $shared_password_confirmation;
 
     protected function rules(): array
     {


### PR DESCRIPTION
#125 

・最初に変数を宣言してなかったため